### PR TITLE
Add a custom filter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
-# sc-filter
+# Custom SoundCloud filter
 
-Browser extension that adds multiple filtering options to your [SoundCloud feed](https://soundcloud.com/feed)
+Browser extension that adds multiple filtering options to your [SoundCloud feed](https://soundcloud.com/feed).
 
-![Example](/docs/screenshot.png)
-
-## Installation
-
-[Firefox](https://addons.mozilla.org/en-US/firefox/addon/soundcloud-feed-filter)
-
-[Chrome](https://chromewebstore.google.com/detail/soundcloud-feed-filter/kbkaecpbbnacnjecgecmfopgojdcomfn)
+Forked from [7x11x13/sc-filter](https://github.com/7x11x13/sc-filter) to add the custom filter option.

--- a/manifest_v2.json
+++ b/manifest_v2.json
@@ -8,7 +8,7 @@
         "48": "icons/icon48.png",
         "128": "icons/icon128.png"
     },
-    "version": "1.0.7",
+    "version": "1.1.0",
     "content_scripts": [
         {
             "matches": ["*://*.soundcloud.com/*"],
@@ -26,7 +26,11 @@
     ],
     "browser_specific_settings": {
         "gecko": {
-            "id": "sc-filter@7x11x13.xyz"
+            "id": "sc-filter@7x11x13.xyz",
+            "data_collection_permissions": {
+                "required": ["none"],
+                "optional": []
+            }
         }
     }
 }

--- a/manifest_v2.json
+++ b/manifest_v2.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
-    "name": "SoundCloud Feed Filter",
-    "description": "Adds multiple filtering options to your SoundCloud feed",
+    "name": "Custom SoundCloud Feed Filter",
+    "description": "Adds multiple filtering options to your SoundCloud feed, including a custom filter.",
     "icons": {
         "16": "icons/icon16.png",
         "32": "icons/icon32.png",
@@ -26,7 +26,7 @@
     ],
     "browser_specific_settings": {
         "gecko": {
-            "id": "sc-filter@7x11x13.xyz",
+            "id": "custom-c-filter@sssppp.xyz",
             "data_collection_permissions": {
                 "required": ["none"],
                 "optional": []

--- a/manifest_v3.json
+++ b/manifest_v3.json
@@ -8,7 +8,7 @@
         "48": "icons/icon48.png",
         "128": "icons/icon128.png"
     },
-    "version": "1.0.7",
+    "version": "1.1.0",
     "content_scripts": [
         {
             "matches": ["*://*.soundcloud.com/*"],
@@ -30,7 +30,11 @@
     ],
     "browser_specific_settings": {
         "gecko": {
-            "id": "sc-filter@7x11x13.xyz"
+            "id": "sc-filter@7x11x13.xyz",
+            "data_collection_permissions": {
+                "required": ["none"],
+                "optional": []
+            }
         }
     }
 }

--- a/manifest_v3.json
+++ b/manifest_v3.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
-    "name": "SoundCloud Feed Filter",
-    "description": "Adds multiple filtering options to your SoundCloud feed",
+    "name": "Custom SoundCloud Feed Filter",
+    "description": "Adds multiple filtering options to your SoundCloud feed, including a custom filter.",
     "icons": {
         "16": "icons/icon16.png",
         "32": "icons/icon32.png",
@@ -30,7 +30,7 @@
     ],
     "browser_specific_settings": {
         "gecko": {
-            "id": "sc-filter@7x11x13.xyz",
+            "id": "custom-c-filter@sssppp.xyz",
             "data_collection_permissions": {
                 "required": ["none"],
                 "optional": []

--- a/src/content.js
+++ b/src/content.js
@@ -62,7 +62,153 @@ const FILTERS = [
   new FeedFilter("Not following", "notFollowing"),
   new FeedFilter("Only singles", "onlySingles"),
   new FeedFilter("Deep cuts", "deepCuts"),
+  new FeedFilter("Custom", "custom"),
 ];
+
+const CUSTOM_FILTER_INDEX = FILTERS.length - 1;
+
+const DEFAULT_CUSTOM_PARAMS = {
+  trackType: "tracks",
+  playCountOp: ">=",
+  playCount: null,
+};
+
+function buildCustomSettings(params) {
+  const container = document.createElement("div");
+  container.id = "sc-filter-custom-settings";
+
+  // Tracks/Mixes toggle
+  const toggleGroup = document.createElement("div");
+  toggleGroup.className = "sc-filter-toggle-group";
+
+  for (const type of ["tracks", "mixes"]) {
+    const btn = document.createElement("button");
+    btn.textContent = type.charAt(0).toUpperCase() + type.slice(1);
+    btn.className = "sc-filter-toggle-btn" + (params.trackType === type ? " active" : "");
+    btn.addEventListener("click", () => {
+      const newParams = Object.assign({}, params, { trackType: type });
+      browser.storage.sync.set({ customSCFilterParams: newParams }).then(() => {
+        window.location.reload();
+      });
+    });
+    toggleGroup.appendChild(btn);
+  }
+
+  // Play count filter
+  const playsGroup = document.createElement("div");
+  playsGroup.className = "sc-filter-plays-group";
+
+  const playsLabel = document.createElement("span");
+  playsLabel.textContent = "Plays:";
+
+  const opSelect = document.createElement("select");
+  opSelect.className = "sc-filter-op-select";
+  for (const [value, label] of [[">=", "\u2265"], ["<=", "\u2264"]]) {
+    const option = document.createElement("option");
+    option.value = value;
+    option.textContent = label;
+    if (params.playCountOp === value) option.selected = true;
+    opSelect.appendChild(option);
+  }
+  opSelect.addEventListener("change", () => {
+    const newParams = Object.assign({}, params, { playCountOp: opSelect.value });
+    browser.storage.sync.set({ customSCFilterParams: newParams }).then(() => {
+      window.location.reload();
+    });
+  });
+
+  const countInput = document.createElement("input");
+  countInput.type = "number";
+  countInput.min = "0";
+  countInput.placeholder = "any";
+  countInput.className = "sc-filter-count-input";
+  if (params.playCount != null) countInput.value = params.playCount;
+
+  const saveCount = () => {
+    const val = countInput.value.trim();
+    const newCount = val === "" ? null : parseInt(val, 10);
+    const newParams = Object.assign({}, params, { playCount: isNaN(newCount) ? null : newCount });
+    browser.storage.sync.set({ customSCFilterParams: newParams }).then(() => {
+      window.location.reload();
+    });
+  };
+
+  countInput.addEventListener("blur", saveCount);
+  countInput.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") saveCount();
+  });
+
+  playsGroup.appendChild(playsLabel);
+  playsGroup.appendChild(opSelect);
+  playsGroup.appendChild(countInput);
+
+  container.appendChild(toggleGroup);
+  container.appendChild(playsGroup);
+
+  return container;
+}
+
+function injectCustomStyles() {
+  if (document.getElementById("sc-filter-styles")) return;
+  const style = document.createElement("style");
+  style.id = "sc-filter-styles";
+  style.textContent = `
+    #sc-filter-custom-settings {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      padding: 8px 0;
+    }
+    .sc-filter-toggle-group {
+      display: flex;
+    }
+    .sc-filter-toggle-btn {
+      background: none;
+      border: 1px solid #ccc;
+      padding: 4px 12px;
+      cursor: pointer;
+      font-size: 13px;
+      color: inherit;
+    }
+    .sc-filter-toggle-btn:first-child {
+      border-radius: 3px 0 0 3px;
+    }
+    .sc-filter-toggle-btn:last-child {
+      border-radius: 0 3px 3px 0;
+      border-left: none;
+    }
+    .sc-filter-toggle-btn.active {
+      background: #f50;
+      border-color: #f50;
+      color: #fff;
+    }
+    .sc-filter-plays-group {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 13px;
+    }
+    .sc-filter-op-select {
+      background: none;
+      border: 1px solid #ccc;
+      border-radius: 3px;
+      padding: 3px 6px;
+      font-size: 14px;
+      color: inherit;
+      cursor: pointer;
+    }
+    .sc-filter-count-input {
+      background: none;
+      border: 1px solid #ccc;
+      border-radius: 3px;
+      padding: 3px 6px;
+      width: 80px;
+      font-size: 13px;
+      color: inherit;
+    }
+  `;
+  document.documentElement.appendChild(style);
+}
 
 function initFilters() {
   if (!document.getElementById("sc-filter-script-1")) {
@@ -73,12 +219,33 @@ function initFilters() {
   }
   if (window.location.href.includes("soundcloud.com/feed")) {
     waitForElement(".stream__header").then((header) => {
-      browser.storage.sync.get("activeSCFeedFilterIndex").then((item) => {
-        const activeFilterIndex = item.activeSCFeedFilterIndex || 0;
+      Promise.all([
+        browser.storage.sync.get("activeSCFeedFilterIndex"),
+        browser.storage.sync.get("customSCFilterParams"),
+      ]).then(([indexItem, paramsItem]) => {
+        const activeFilterIndex = indexItem.activeSCFeedFilterIndex || 0;
+        const customParams = Object.assign(
+          {},
+          DEFAULT_CUSTOM_PARAMS,
+          paramsItem.customSCFilterParams || {}
+        );
+
         const filterMenu = new FilterMenu(FILTERS, activeFilterIndex);
         header.replaceChildren(filterMenu.root);
 
+        if (activeFilterIndex === CUSTOM_FILTER_INDEX) {
+          injectCustomStyles();
+          const settingsPanel = buildCustomSettings(customParams);
+          header.appendChild(settingsPanel);
+        }
+
         if (!document.getElementById("sc-filter-script-2")) {
+          if (activeFilterIndex === CUSTOM_FILTER_INDEX) {
+            const paramsScript = document.createElement("script");
+            paramsScript.textContent = `window.scFilterParams = ${JSON.stringify(customParams)};`;
+            document.documentElement.appendChild(paramsScript);
+          }
+
           let script = document.createElement("script");
           script.id = "sc-filter-script-2";
           script.src = browser.runtime.getURL(

--- a/src/filters/custom.js
+++ b/src/filters/custom.js
@@ -1,0 +1,18 @@
+window.activeSCFeedFilter = (data) => (item) => {
+  const params = window.scFilterParams || {};
+  if (!("track" in item)) return false; // always exclude playlists
+
+  // Hard to imagine the 30 min threshold failing to distinguish tracks and mixes,
+  // so this is a toggle instead of a flexible input.
+  const durationMin = item.track.full_duration / 1000 / 60;
+  if (params.trackType === "tracks" && durationMin >= 30) return false;
+  if (params.trackType === "mixes" && durationMin < 30) return false;
+
+  if (params.playCount != null && item.track.playback_count != null) {
+    const op = params.playCountOp || ">=";
+    if (op === ">=" && item.track.playback_count < params.playCount) return false;
+    if (op === "<=" && item.track.playback_count > params.playCount) return false;
+  }
+
+  return true;
+};


### PR DESCRIPTION
The custom filter enables filtering for tracks/mixes and filtering for play count together.

The tracks/mixes filter is implemented as a toggle using the 30 min threshold from `filters/onlySingles.js`. 

The play count filter is implemented as a user input with an operator toggle.

This requires reading filter parameters from `browser.storage.sync` in `content.js` and injecting them as a page-context global which `filters/custom.js` reads. This follows the pattern used for `auxData`. 

I wrote this as a personal project, because I most often scroll Soundcloud looking for mixes with at least a few dozen plays. It works well as a temporary firefox add-on. I thought about uploading it to Mozilla as a separate add-on, but thought I'd see if you want to incorporate the addition to your existing add-on first.